### PR TITLE
Adapt crawler to latest API change in registry

### DIFF
--- a/src/main/scala/de/upb/cs/swt/delphi/crawler/Configuration.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/crawler/Configuration.scala
@@ -42,7 +42,8 @@ class Configuration {
       "Default ElasticSearch instance",
       ComponentType.ElasticSearch,
       None,
-      InstanceState.Running)
+      InstanceState.Running,
+      List.empty[String])
   }
 
   val mavenRepoBase: URI = new URI("http://repo1.maven.org/maven2/") // TODO: Create a local demo server "http://localhost:8881/maven2/"

--- a/src/main/scala/de/upb/cs/swt/delphi/crawler/instancemanagement/Instance.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/crawler/instancemanagement/Instance.scala
@@ -54,7 +54,7 @@ trait JsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
     }
   }
 
-  implicit val instanceFormat : JsonFormat[Instance] = jsonFormat7(Instance)
+  implicit val instanceFormat : JsonFormat[Instance] = jsonFormat8(Instance)
 }
 
 final case class Instance (
@@ -64,7 +64,8 @@ final case class Instance (
                             name: String,
                             componentType: InstanceEnums.ComponentType,
                             dockerId: Option[String],
-                            instanceState: InstanceEnums.State
+                            instanceState: InstanceEnums.State,
+                            labels: List[String]
                           ) {}
 
 object InstanceEnums {

--- a/src/main/scala/de/upb/cs/swt/delphi/crawler/instancemanagement/InstanceRegistry.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/crawler/instancemanagement/InstanceRegistry.scala
@@ -251,7 +251,7 @@ object InstanceRegistry extends JsonSupport with AppLogging
 
   private def createInstance(id: Option[Long], controlPort : Int, name : String) : Instance =
     Instance(id, InetAddress.getLocalHost.getHostAddress,
-      controlPort, name, ComponentType.Crawler, None, InstanceState.Running)
+      controlPort, name, ComponentType.Crawler, None, InstanceState.Running, List.empty[String])
 
 
   object ReportOperationType extends Enumeration {

--- a/src/main/scala/de/upb/cs/swt/delphi/crawler/instancemanagement/InstanceRegistry.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/crawler/instancemanagement/InstanceRegistry.scala
@@ -149,7 +149,8 @@ object InstanceRegistry extends JsonSupport with AppLogging
     if(!configuration.usingInstanceRegistry) {
       Failure(new RuntimeException("Cannot get ElasticSearch instance from Instance Registry, no Instance Registry available."))
     } else {
-      val request = HttpRequest(method = HttpMethods.GET, configuration.instanceRegistryUri + "/matchingInstance?ComponentType=ElasticSearch")
+      val request = HttpRequest(method = HttpMethods.GET, configuration.instanceRegistryUri +
+        s"/matchingInstance?Id=${configuration.instanceId.getOrElse(-1)}&ComponentType=ElasticSearch")
 
       Await.result(Http(system).singleRequest(request) map {response =>
         response.status match {
@@ -188,7 +189,8 @@ object InstanceRegistry extends JsonSupport with AppLogging
         val idToPost = configuration.elasticSearchInstance.id.getOrElse(-1L)
         val request = HttpRequest(
           method = HttpMethods.POST,
-          configuration.instanceRegistryUri + s"/matchingResult?Id=$idToPost&MatchingSuccessful=$isElasticSearchReachable")
+          configuration.instanceRegistryUri +
+            s"/matchingResult?CallerId=${configuration.instanceId.getOrElse(-1)}&MatchedInstanceId=$idToPost&MatchingSuccessful=$isElasticSearchReachable")
 
         Await.result(Http(system).singleRequest(request) map {response =>
           if(response.status == StatusCodes.OK){


### PR DESCRIPTION
**Reason for this PR**
The API of the Instance Registry has been change [lately](https://github.com/delphi-hub/delphi-registry/pull/33). The goal was to support new UI requirements. The relevant changes are:
- */matchingInstance* and */matchingResult* now require an additional parameter containing the caller-Id
- The *Instance* now has a new attribute called *labels* of type List[String]

This PR adapts the crawler to support the new API version.

**Changes**
- Added attribute *labels: List[String]* to case class *Instance*
- Changed calls to */matchingInstance* and */matchingResult* to post the parameter *callerId* as well