### PR TITLE
Adapt Crawler to latest changes of the registry interface

### DIFF
--- a/src/main/scala/de/upb/cs/swt/delphi/crawler/Configuration.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/crawler/Configuration.scala
@@ -21,7 +21,7 @@ import java.net.URI
 import akka.stream.ThrottleMode
 import com.sksamuel.elastic4s.ElasticsearchClientUri
 import de.upb.cs.swt.delphi.crawler.instancemanagement.InstanceEnums.{ComponentType, InstanceState}
-import de.upb.cs.swt.delphi.crawler.instancemanagement.{Instance, InstanceRegistry}
+import de.upb.cs.swt.delphi.crawler.instancemanagement.{Instance, InstanceLink, InstanceRegistry}
 
 import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
@@ -43,7 +43,9 @@ class Configuration {
       ComponentType.ElasticSearch,
       None,
       InstanceState.Running,
-      List.empty[String])
+      List.empty[String],
+      List.empty[InstanceLink],
+      List.empty[InstanceLink])
   }
 
   val mavenRepoBase: URI = new URI("http://repo1.maven.org/maven2/") // TODO: Create a local demo server "http://localhost:8881/maven2/"

--- a/src/main/scala/de/upb/cs/swt/delphi/crawler/instancemanagement/InstanceLink.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/crawler/instancemanagement/InstanceLink.scala
@@ -1,0 +1,53 @@
+// Copyright (C) 2018 The Delphi Team.
+// See the LICENCE file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package de.upb.cs.swt.delphi.crawler.instancemanagement
+
+import LinkEnums.LinkState
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import spray.json.{DefaultJsonProtocol, DeserializationException, JsString, JsValue, JsonFormat}
+
+trait InstanceLinkJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
+
+  implicit val linkStateFormat: JsonFormat[LinkState] = new JsonFormat[LinkState] {
+    override def read(value: JsValue): LinkState = value match {
+      case JsString(s) => s match {
+        case "Assigned" => LinkState.Assigned
+        case "Outdated" => LinkState.Outdated
+        case "Failed" => LinkState.Failed
+        case x => throw DeserializationException(s"Unexpected string value $x for LinkState.")
+      }
+      case y => throw DeserializationException(s"Unexpected type $y during deserialization of LinkState")
+    }
+
+    override def write(linkState: LinkState): JsValue = JsString(linkState.toString)
+  }
+
+  implicit val instanceLinkFormat: JsonFormat[InstanceLink] =
+    jsonFormat3(InstanceLink)
+}
+
+
+final case class InstanceLink(idFrom: Long, idTo:Long, linkState: LinkState)
+
+object LinkEnums {
+  type LinkState = LinkState.Value
+
+  object LinkState extends Enumeration {
+    val Assigned: Value =  Value("Assigned")
+    val Failed: Value = Value("Failed")
+    val Outdated: Value = Value("Outdated")
+  }
+}

--- a/src/main/scala/de/upb/cs/swt/delphi/crawler/instancemanagement/InstanceRegistry.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/crawler/instancemanagement/InstanceRegistry.scala
@@ -32,7 +32,7 @@ import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 import spray.json._
 
-object InstanceRegistry extends JsonSupport with AppLogging
+object InstanceRegistry extends InstanceJsonSupport with AppLogging
 {
 
   implicit val system : ActorSystem = Crawler.system
@@ -251,7 +251,8 @@ object InstanceRegistry extends JsonSupport with AppLogging
 
   private def createInstance(id: Option[Long], controlPort : Int, name : String) : Instance =
     Instance(id, InetAddress.getLocalHost.getHostAddress,
-      controlPort, name, ComponentType.Crawler, None, InstanceState.Running, List.empty[String])
+      controlPort, name, ComponentType.Crawler, None, InstanceState.Running,
+      List.empty[String], List.empty[InstanceLink], List.empty[InstanceLink])
 
 
   object ReportOperationType extends Enumeration {


### PR DESCRIPTION
**Reason for this PR**
The interface of the instance registry has been changed [lately](https://github.com/delphi-hub/delphi-registry/pull/33). The reason for this was to better support the requirements of the Delphi-Management state management. The relevant change is:
- The attributes ```linksTo: List[InstanceLink]``` and ```linksFrom: List[InstanceLink]``` have been added to the Instance class

This PR adapts the Crawler to this change. The same has been done for the [WebApp](https://github.com/delphi-hub/delphi-webapp/pull/24) and [WebApi](https://github.com/delphi-hub/delphi-webapi/pull/36).

**Changes**
- Added file ```InstanceLink.scala``` containing the JSON support
- Added new attributes to Instance
