### PR TITLE
Introduced JWT based authorization for registry communication

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,6 +55,8 @@ libraryDependencies ++= Seq(
 
 libraryDependencies += "org.json4s" %% "json4s-jackson" % "3.5.3"
 
+libraryDependencies += "com.pauldijou" %% "jwt-core" % "1.0.0"
+
 libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.3" % Runtime
 
 val elastic4sVersion = "6.3.0"

--- a/src/main/scala/de/upb/cs/swt/delphi/crawler/Configuration.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/crawler/Configuration.scala
@@ -96,6 +96,8 @@ class Configuration {
 
   lazy val instanceId : Option[Long] = InstanceRegistry.handleInstanceStart(this)
 
+  val jwtSecretKey: String  = sys.env.getOrElse("DELPHI_JWT_SECRET","changeme")
+
   case class Throttle(element : Int, per : FiniteDuration, maxBurst : Int, mode : ThrottleMode)
 }
 

--- a/src/main/scala/de/upb/cs/swt/delphi/crawler/authorization/AuthProvider.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/crawler/authorization/AuthProvider.scala
@@ -25,8 +25,8 @@ object AuthProvider {
       .issuedNow
       .expiresIn(validFor * 60)
       .startsNow
-      .+("user_id", if (useGenericName) configuration.instanceName else s"${configuration.instanceId.get}")
-      .+("user_type", "Component")
+      . + ("user_id", if (useGenericName) configuration.instanceName else s"${configuration.instanceId.get}")
+      . + ("user_type", "Component")
 
 
     Jwt.encode(claim, configuration.jwtSecretKey, JwtAlgorithm.HS256)

--- a/src/main/scala/de/upb/cs/swt/delphi/crawler/authorization/AuthProvider.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/crawler/authorization/AuthProvider.scala
@@ -1,0 +1,35 @@
+// Copyright (C) 2018 The Delphi Team.
+// See the LICENCE file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package de.upb.cs.swt.delphi.crawler.authorization
+
+import de.upb.cs.swt.delphi.crawler.Configuration
+import pdi.jwt.{Jwt, JwtAlgorithm, JwtClaim}
+
+object AuthProvider {
+
+  def generateJwt(validFor: Long = 1, useGenericName: Boolean = false) (implicit configuration: Configuration): String = {
+    val claim = JwtClaim()
+      .issuedNow
+      .expiresIn(validFor * 60)
+      .startsNow
+      .+("user_id", if (useGenericName) configuration.instanceName else s"${configuration.instanceId.get}")
+      .+("user_type", "Component")
+
+
+    Jwt.encode(claim, configuration.jwtSecretKey, JwtAlgorithm.HS256)
+  }
+
+}


### PR DESCRIPTION
**Reason for this PR**
The instance registry will require authentication based on JSON Web Tokens (JWTs) soon (as described [here](https://github.com/delphi-hub/delphi-registry/issues/64)). The components of the Delphi system have to be able to generate valid JWTs based on a secret that is either passed in an environment variable or in the configuration file. They have to add the encoded token in the ```Authorization``` header of every HTTP request issued to the registry. For more information see the respective [issue](https://github.com/delphi-hub/delphi-registry/issues/35).

**Changes in this PR**
- The Crawler is now able to generate valid JWTs based on a secret specified in an environment variable (using HS256 signature algorithm)
- The Crawler sends an encoded valid JWT with every request issued to the registry
