### PR TITLE
Adapted registry interface to newest API version

### DIFF
--- a/src/main/scala/de/upb/cs/swt/delphi/crawler/instancemanagement/InstanceRegistry.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/crawler/instancemanagement/InstanceRegistry.scala
@@ -194,7 +194,7 @@ object InstanceRegistry extends InstanceJsonSupport with AppLogging
       } else {
         val idToPost = configuration.elasticSearchInstance.id.getOrElse(-1L)
 
-        val MatchingData = JsObject("MatchingSuccessful" -> JsBoolean(isElasticSearchReachable),
+        val matchingData = JsObject("MatchingSuccessful" -> JsBoolean(isElasticSearchReachable),
           "SenderId" -> JsNumber(configuration.instanceId.getOrElse(-1L)))
 
         val request = HttpRequest(
@@ -203,7 +203,7 @@ object InstanceRegistry extends InstanceJsonSupport with AppLogging
 
         Await.result(Http(system).singleRequest(request
           .withHeaders(RawHeader("Authorization", s"Bearer ${AuthProvider.generateJwt()(configuration)}"))
-          .withEntity(ContentTypes.`application/json`, ByteString(MatchingData.toJson.toString))) map {response =>
+          .withEntity(ContentTypes.`application/json`, ByteString(matchingData.toJson.toString))) map {response =>
           if(response.status == StatusCodes.OK){
             log.info("Successfully posted matching result to Instance Registry.")
             Success()


### PR DESCRIPTION
**Reason for this PR**
[This PR](https://github.com/delphi-hub/delphi-registry/pull/90) changes the Delphi registry HTTP interface in order to be more REST-like (as discussed [here](https://github.com/delphi-hub/delphi-registry/issues/57)). The status report endpoints that each of the Delphi components calls have to be adapted to the new API specification.

**Changes in this PR**
- Adapted URLs that are being called to the new API schema

**Related PRs**
The same has been done for the
- [WebApi](https://github.com/delphi-hub/delphi-webapi/pull/42)
- [WebApp](https://github.com/delphi-hub/delphi-webapp/pull/26)