### PR TITLE
Upgrade to OPAL 4.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -87,9 +87,10 @@ resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repos
 
 val opalVersion = "4.0.0"
 libraryDependencies ++= Seq(
-  "de.opal-project" % "common_2.12" % opalVersion,
-  "de.opal-project" % "framework_2.12" % opalVersion,
-  "de.opal-project" % "hermes_2.12" % opalVersion
+  "de.opal-project" % "common_2.12" % opalVersion exclude("com.fasterxml.jackson.core", "jackson-databind"),
+
+  "de.opal-project" % "framework_2.12" % opalVersion exclude("com.fasterxml.jackson.core", "jackson-databind"),
+  "de.opal-project" % "hermes_2.12" % opalVersion exclude("com.fasterxml.jackson.core", "jackson-databind")
 )
 
 val mavenVersion = "3.5.2"

--- a/build.sbt
+++ b/build.sbt
@@ -85,16 +85,11 @@ libraryDependencies ++= Seq(
 
 resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
 
-val opalVersion = "1.0.0"
+val opalVersion = "4.0.0"
 libraryDependencies ++= Seq(
-  "de.opal-project" % "common_2.12" % opalVersion
-    exclude("com.fasterxml.jackson.datatype", "jackson-datatype-jsr310"),
-  //https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONDATATYPE-173759
-  "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.9.8",
-
-  "de.opal-project" % "opal-developer-tools_2.12" % opalVersion
-    exclude("com.google.protobuf", "protobuf-java"),
-  "com.google.protobuf" % "protobuf-java" % "3.4.0"
+  "de.opal-project" % "common_2.12" % opalVersion,
+  "de.opal-project" % "framework_2.12" % opalVersion,
+  "de.opal-project" % "hermes_2.12" % opalVersion
 )
 
 val mavenVersion = "3.5.2"

--- a/src/main/scala/de/upb/cs/swt/delphi/crawler/processing/HermesAnalyzer.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/crawler/processing/HermesAnalyzer.scala
@@ -18,9 +18,10 @@ package de.upb.cs.swt.delphi.crawler.processing
 
 import java.io._
 import java.net.URL
-
 import org.opalj.br.analyses.Project
 import org.opalj.hermes._
+
+import scala.collection.JavaConverters.asScalaIteratorConverter
 
 /**
   * Custom Hermes runner for Delphi
@@ -31,17 +32,17 @@ import org.opalj.hermes._
 class HermesAnalyzer(project: Project[URL]) extends HermesCore {
 
 
-  override def updateProjectData(f: => Unit): Unit = Hermes.synchronized {
+  override def updateProjectData(f: => Unit): Unit = HermesAnalyzer.synchronized {
     f
   }
 
-  override def reportProgress(f: => Double): Unit = Hermes.synchronized {
+  override def reportProgress(f: => Double): Unit = HermesAnalyzer.synchronized {
     f
   }
 
   def analyzeProject(): Iterator[(FeatureQuery, TraversableOnce[Feature[URL]])] = {
     for {
-      projectFeatures <- featureMatrix.iterator
+      projectFeatures <- featureMatrix.iterator().asScala
       projectConfiguration = projectFeatures.projectConfiguration
       (featureQuery, features) <- projectFeatures.featureGroups.par
     } yield {
@@ -58,7 +59,7 @@ class HermesAnalyzer(project: Project[URL]) extends HermesCore {
 
 
   override lazy val registeredQueries: List[Query] = {
-    queries.values.flatten.map { s => Query(s, true) }.toList
+    queries.values.flatten.map { s => new Query(s, true) }.toList
   }
 
   val VERY_SLOW = 'VERY_SLOW
@@ -116,11 +117,11 @@ object HermesAnalyzer extends HermesCore {
     tempConfigFile
   }
 
-  override def updateProjectData(f: => Unit): Unit = Hermes.synchronized {
+  override def updateProjectData(f: => Unit): Unit = HermesAnalyzer.synchronized {
     f
   }
 
-  override def reportProgress(f: => Double): Unit = Hermes.synchronized {
+  override def reportProgress(f: => Double): Unit = HermesAnalyzer.synchronized {
     f
   }
 

--- a/src/main/scala/de/upb/cs/swt/delphi/crawler/processing/HermesAnalyzer.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/crawler/processing/HermesAnalyzer.scala
@@ -30,7 +30,7 @@ import scala.collection.JavaConverters.asScalaIteratorConverter
   *
   */
 class HermesAnalyzer(project: Project[URL]) extends HermesCore {
-
+  initialize(HermesAnalyzer.temporaryConfigFile())
 
   override def updateProjectData(f: => Unit): Unit = HermesAnalyzer.synchronized {
     f

--- a/src/main/scala/de/upb/cs/swt/delphi/crawler/tools/ClassStreamReader.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/crawler/tools/ClassStreamReader.scala
@@ -69,7 +69,7 @@ trait ClassStreamReader {
         futures ::= Future[List[(ClassFile, String)]] {
           val cfs = reader.ClassFile(new DataInputStream(new ByteArrayInputStream(entryBytes)))
           cfs map { cf => (cf, entryName) }
-        }(org.opalj.concurrent.OPALExecutionContext)
+        }(org.opalj.concurrent.OPALUnboundedExecutionContext)
       }
       je = in.getNextJarEntry()
     }

--- a/src/test/scala/de/upb/cs/swt/delphi/crawler/preprocessing/MavenDownloadActorTest.scala
+++ b/src/test/scala/de/upb/cs/swt/delphi/crawler/preprocessing/MavenDownloadActorTest.scala
@@ -38,13 +38,11 @@ class MavenDownloadActorTest extends TestKit(ActorSystem("DownloadActor"))
   with WordSpecLike
   with Matchers
   with BeforeAndAfterAll {
-  override def afterAll {
-    TestKit.shutdownActorSystem(system)
-  }
+
 
   "The maven download actor" must {
     "create a maven artifact with a jar and pom file" in {
-      val mavenIdentifier = new MavenIdentifier("http://central.maven.org/maven2/", "junit", "junit", "4.12")
+      val mavenIdentifier = new MavenIdentifier("https://repo1.maven.org/maven2/", "junit", "junit", "4.12")
       val downloadActor = system.actorOf(MavenDownloadActor.props)
 
       implicit val timeout = Timeout(10 seconds)

--- a/src/test/scala/de/upb/cs/swt/delphi/crawler/preprocessing/MavenDownloaderSpec.scala
+++ b/src/test/scala/de/upb/cs/swt/delphi/crawler/preprocessing/MavenDownloaderSpec.scala
@@ -21,13 +21,13 @@ import de.upb.cs.swt.delphi.crawler.preprocessing.Common._
 
 class MavenDownloaderSpec extends FlatSpec with Matchers {
   "MavenDownloader" should "save jar file" in {
-    val mavenIdentifier = new MavenIdentifier("http://central.maven.org/maven2/", "junit", "junit", "4.12")
+    val mavenIdentifier = new MavenIdentifier("https://repo1.maven.org/maven2/", "junit", "junit", "4.12")
     val downloader = new MavenDownloader(mavenIdentifier)
     val jarStream = downloader.downloadJar()
     checkJar(jarStream.is)
   }
   "MavenDownloader" should "save pom file" in {
-    val mavenIdentifier = new MavenIdentifier("http://central.maven.org/maven2/", "junit", "junit", "4.12")
+    val mavenIdentifier = new MavenIdentifier("https://repo1.maven.org/maven2/", "junit", "junit", "4.12")
     val downloader = new MavenDownloader(mavenIdentifier)
     val pomStream = downloader.downloadPom()
     checkPom(pomStream.is)

--- a/src/test/scala/de/upb/cs/swt/delphi/crawler/preprocessing/MavenURLConstructionCheck.scala
+++ b/src/test/scala/de/upb/cs/swt/delphi/crawler/preprocessing/MavenURLConstructionCheck.scala
@@ -21,17 +21,17 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class MavenURLConstructionCheck extends FlatSpec with Matchers {
   "Regular identifiers" should "create regular urls" in {
-    val reg1 = MavenIdentifier("http://repo1.maven.org/maven2/", "log4j", "log4j", "1.2.9")
-    val reg2 = MavenIdentifier("http://repo1.maven.org/maven2/", "de.tu-darmstadt.stg", "sootkeeper", "1.0")
-    val reg3 = MavenIdentifier("http://repo1.maven.org/maven2/", "de.tuebingen.uni.sfs.germanet", "germanet-api", "13.1.0")
+    val reg1 = MavenIdentifier("https://repo1.maven.org/maven2/", "log4j", "log4j", "1.2.9")
+    val reg2 = MavenIdentifier("https://repo1.maven.org/maven2/", "de.tu-darmstadt.stg", "sootkeeper", "1.0")
+    val reg3 = MavenIdentifier("https://repo1.maven.org/maven2/", "de.tuebingen.uni.sfs.germanet", "germanet-api", "13.1.0")
 
-    reg1.toJarLocation.toString shouldBe "http://repo1.maven.org/maven2/log4j/log4j/1.2.9/log4j-1.2.9.jar"
-    reg2.toJarLocation.toString shouldBe "http://repo1.maven.org/maven2/de/tu-darmstadt/stg/sootkeeper/1.0/sootkeeper-1.0.jar"
-    reg3.toJarLocation.toString shouldBe "http://repo1.maven.org/maven2/de/tuebingen/uni/sfs/germanet/germanet-api/13.1.0/germanet-api-13.1.0.jar"
+    reg1.toJarLocation.toString shouldBe "https://repo1.maven.org/maven2/log4j/log4j/1.2.9/log4j-1.2.9.jar"
+    reg2.toJarLocation.toString shouldBe "https://repo1.maven.org/maven2/de/tu-darmstadt/stg/sootkeeper/1.0/sootkeeper-1.0.jar"
+    reg3.toJarLocation.toString shouldBe "https://repo1.maven.org/maven2/de/tuebingen/uni/sfs/germanet/germanet-api/13.1.0/germanet-api-13.1.0.jar"
 
-    reg1.toPomLocation.toString shouldBe "http://repo1.maven.org/maven2/log4j/log4j/1.2.9/log4j-1.2.9.pom"
-    reg2.toPomLocation.toString shouldBe "http://repo1.maven.org/maven2/de/tu-darmstadt/stg/sootkeeper/1.0/sootkeeper-1.0.pom"
-    reg3.toPomLocation.toString shouldBe "http://repo1.maven.org/maven2/de/tuebingen/uni/sfs/germanet/germanet-api/13.1.0/germanet-api-13.1.0.pom"
+    reg1.toPomLocation.toString shouldBe "https://repo1.maven.org/maven2/log4j/log4j/1.2.9/log4j-1.2.9.pom"
+    reg2.toPomLocation.toString shouldBe "https://repo1.maven.org/maven2/de/tu-darmstadt/stg/sootkeeper/1.0/sootkeeper-1.0.pom"
+    reg3.toPomLocation.toString shouldBe "https://repo1.maven.org/maven2/de/tuebingen/uni/sfs/germanet/germanet-api/13.1.0/germanet-api-13.1.0.pom"
   }
 
 

--- a/src/test/scala/de/upb/cs/swt/delphi/crawler/processing/HermesTest.scala
+++ b/src/test/scala/de/upb/cs/swt/delphi/crawler/processing/HermesTest.scala
@@ -48,7 +48,7 @@ class HermesTest extends FlatSpec with Matchers with BeforeAndAfterAll {
 
   "HermesVersion" should "be a valid version string" in {
     HermesAnalyzer.HermesVersion shouldBe a [String]
-    HermesAnalyzer.HermesVersion shouldBe "1.0.0"
+    HermesAnalyzer.HermesVersion shouldBe "4.0.0"
   }
 
 


### PR DESCRIPTION
This PR upgrades the dependency to the OPAL framework from `1.0.0` to `4.0.0`. Changes were done mostly in code that is not currently used in the crawler (ie the CallGraph generation / unresolved method matching), but functionality should be equivalent. However, i am not able to verify that, as there is no tests available for these functions yet.

Surprisingly, the code related to Hermes stayed pretty much the same, and the tests still work as intended.

Also in this PR: Changed `http://` to `https://` in a couple of test files to make them work again. 